### PR TITLE
fix(opensource-guard): rename job + full-tree fallback

### DIFF
--- a/.github/workflows/opensource-guard.yml
+++ b/.github/workflows/opensource-guard.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  check:
+  opensource-guard:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/check-opensource.sh
+++ b/scripts/check-opensource.sh
@@ -22,16 +22,28 @@ if [ ! -f "$DENY_FILE" ]; then
   exit 2
 fi
 
+# Determine scan mode: diff vs full-tree.
+# Full-tree is used when the BASE ref is unknown or there is no merge-base
+# with HEAD (orphan branch, force-push rewriting history, first push, etc.).
+# In those cases we must scan everything in HEAD, otherwise an orphan commit
+# containing internal files would be waved through.
+SCAN_MODE="diff"
 if ! git rev-parse --verify "$BASE" >/dev/null 2>&1; then
-  echo "error: base ref '$BASE' does not exist. Try: git fetch origin" >&2
-  exit 2
+  echo "check-opensource: base ref '$BASE' not found — full-tree scan" >&2
+  SCAN_MODE="full"
+elif ! git merge-base "$BASE" HEAD >/dev/null 2>&1; then
+  echo "check-opensource: no merge-base with $BASE — full-tree scan" >&2
+  SCAN_MODE="full"
 fi
 
-# Added / Copied / Modified / Renamed — exclude Deletions.
-CHANGED=$(git diff --name-only --diff-filter=ACMR "$BASE"...HEAD || true)
+if [ "$SCAN_MODE" = "full" ]; then
+  CHANGED=$(git ls-files)
+else
+  CHANGED=$(git diff --name-only --diff-filter=ACMR "$BASE"...HEAD || true)
+fi
 
 if [ -z "$CHANGED" ]; then
-  echo "check-opensource: no added/modified files vs $BASE — skip"
+  echo "check-opensource: no files to scan — skip"
   exit 0
 fi
 


### PR DESCRIPTION
- rename CI job 'check' -> 'opensource-guard' (clearer as required check name)
- script: when BASE ref missing or no merge-base with HEAD, fall back to full-tree scan instead of silently skipping. Fixes a hole where orphan push / force-push / first-push could bypass the guard.

## Summary

<!-- Describe what this PR changes and why. -->

## Changes

<!-- List the key changes made. -->

-

## Testing

<!-- How was this change tested? -->

- [ ] Unit tests added / updated (`pnpm test:unit` passes)
- [ ] Tested manually with Demo account (`bash test/smoke.sh`)
- [ ] MCP e2e tests run (`node test/mcp-e2e.mjs`)
- [ ] Not testable without credentials (describe why below)

## Checklist

- [ ] `pnpm build` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit` passes
- [ ] Relevant documentation updated (README, ARCHITECTURE.md, CHANGELOG.md)
- [ ] No API keys or credentials included in this PR
